### PR TITLE
Fix Project.add_marker/add_region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Fix setting color in [`Project.add_marker`] and [`Project.add_region`] methods
 - Access to tracks by name (example: `project.tracks["PIANO"]`)
 - Track selection helpers at the project level:
   * Methods [`Project.select_all_tracks`], [`Project.unselect_all_tracks`]
@@ -15,6 +14,9 @@ All notable changes to this project will be documented in this file.
 - Mute and solo helpers on `Track`:
   * Methods [`Track.solo`], [`Track.mute`], [`Track.unsolo`], [`Track.unmute`],
   * Properties [`Track.is_solo`] and [`Track.is_muted`]. Manually setting them is equivalent to calling the methods above.
+
+### Fixed
+- Fix setting color in [`Project.add_marker`] and [`Project.add_region`] methods
 
 ## [0.3.0](https://github.com/RomeoDespres/reapy/releases/tag/0.3.0) - 2019-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Fix setting color in [`Project.add_marker`] and [`Project.add_region`] methods
 - Access to tracks by name (example: `project.tracks["PIANO"]`)
 - Track selection helpers at the project level:
   * Methods [`Project.select_all_tracks`], [`Project.unselect_all_tracks`]

--- a/reapy/core/project/project.py
+++ b/reapy/core/project/project.py
@@ -62,7 +62,7 @@ class Project(ReapyObject):
         be returned.
         """
         if isinstance(color, tuple):
-            color = reapy.get_native_color(*color)
+            color = reapy.rgb_to_native(color) | 0x1000000
         marker_id = RPR.AddProjectMarker2(
             self.id, False, position, 0, name, -1, color
         )
@@ -91,7 +91,7 @@ class Project(ReapyObject):
             New region.
         """
         if isinstance(color, tuple):
-            color = reapy.rgb_to_native(color)
+            color = reapy.rgb_to_native(color) | 0x1000000
         region_id = RPR.AddProjectMarker2(
             self.id, True, start, end, name, -1, color
         )


### PR DESCRIPTION
Fix Project.add_marker/add_region

The issue is that `AddProjectMarker2` documentation notes that `color` should be result of `ColorToNative(r,g,b)|0x1000000`. Previous version wouldn't set color (at least on MacOSX).