### PR TITLE
Fix reapy server start (config encoding + local site-packages dir)

### DIFF
--- a/reapy/config.py
+++ b/reapy/config.py
@@ -6,6 +6,7 @@ from configparser import ConfigParser
 from collections import OrderedDict
 import json
 import os
+import shutil
 
 REAPY_SERVER_PORT = 2306
 WEB_INTERFACE_PORT = 2307
@@ -39,32 +40,19 @@ class Config(ConfigParser):
     def __init__(self):
         super(Config, self).__init__(strict=False, delimiters="=", dict_type=CaseInsensitiveDict)
         self.optionxform = str
-        ini_filename = reapy.get_ini_file()
-        self.read(ini_filename, encoding='utf8')
+        self.ini_file = reapy.get_ini_file()
+        self.read(self.ini_file, encoding='utf8')
 
     def write(self):
-        ini_filename = reapy.get_ini_file()
-        with open(ini_filename, encoding='utf8') as f_old:
-            old_config_content = f_old.read()
-
-        # this is to save first config which user had before trying reapy
-        ini_before_reapy_filename = ini_filename + '.before-reapy.bak'
-        if not os.path.exists(ini_before_reapy_filename):
-            with open(ini_before_reapy_filename, 'w', encoding='utf8') as f:
-                f.write(old_config_content)
-
-        # this is current ini file backup copy
-        ini_bak_filename = ini_filename + '.bak'
-        with open(ini_bak_filename, 'w', encoding='utf8') as f:
-            f.write(old_config_content)
-
-        # write to tmp file first
-        tmp_filename = ini_filename + '.tmp'
-        with open(tmp_filename, "w", encoding='utf8') as f:
+        # Backup config state before user has ever tried reapy
+        before_reapy_file = self.ini_file + '.before-reapy.bak'
+        if not os.path.exists(before_reapy_file):
+            shutil.copy(self.ini_file, before_reapy_file)
+        # Backup current config
+        shutil.copy(self.ini_file, ini_file + '.bak')
+        # Write config
+        with open(self.ini_file, "w", encoding='utf8') as f:
             super(Config, self).write(f, False)
-
-        # then rename tmp to ini file
-        os.replace(tmp_filename, ini_filename)
 
 
 def create_new_web_interface(port):

--- a/reapy/config.py
+++ b/reapy/config.py
@@ -36,13 +36,20 @@ class Config(ConfigParser):
 
     """Parser for REAPER .ini file."""
 
+    encoding = None
+
     def __init__(self):
         super(Config, self).__init__(strict=False, delimiters="=", dict_type=CaseInsensitiveDict)
         self.optionxform = str
-        self.read(reapy.get_ini_file())
+        ini_filename = reapy.get_ini_file()
+        try:
+            self.read(ini_filename)
+        except UnicodeDecodeError as exc:
+            self.encoding = 'utf8'
+            self.read(ini_filename, encoding=self.encoding)
 
     def write(self):
-        with open(reapy.get_ini_file(), "w") as f:
+        with open(reapy.get_ini_file(), "w", encoding=self.encoding) as f:
             super(Config, self).write(f, False)
 
 

--- a/reapy/reascripts/activate_reapy_server.py
+++ b/reapy/reascripts/activate_reapy_server.py
@@ -11,7 +11,6 @@ import reapy
 
 import os
 import site
-import sys
 
 if reapy.is_inside_reaper():
     from reapy import reascript_api as RPR
@@ -31,8 +30,11 @@ def main_loop():
 
 def generate_api_module():
     function_names = RPR.__all__
+    sitepackages_dir = site.getusersitepackages()
+    if not os.path.exists(sitepackages_dir):
+        os.makedirs(sitepackages_dir, 0o770, False)
     filepath = os.path.join(
-        site.getusersitepackages(), "reapy_generated_api.py"
+        sitepackages_dir, "reapy_generated_api.py"
     )
     with open(filepath, "w") as file:
         lines = [


### PR DESCRIPTION
Fix reapy server start (config encoding + local site-packages dir)

1. My `reaper.ini` is UTF8-encoded because it contains folder names with Cyrillic chars. That's the reason to modify `reapy/config.py`. Second commit is to avoid losing original `reaper.ini` if config writing goes wrong. Writing in UTF-8 is compatible with writing in ASCII, that's why I made it default encoding. More elegant solutions are absolutely welcome.
2. `site.getusersitepackages()` returned a non-existent path due to that simple fact that I had not installed anything locally for Python3 (indeed, I had installed some in PyCharm venv, but `site` module knows nothing of it). That's the reason to modify `generate_api_module()`.
3. `sys` seems to be unused import in `activate_server_reapy.py`, things work fine without it. If there's an obscure reason to keep it here, just tell me and I'll add it back in another commit.