### PR TITLE
Fix mistypes and error calls

### DIFF
--- a/reapy/core/envelope.py
+++ b/reapy/core/envelope.py
@@ -1,3 +1,4 @@
+import reapy
 from reapy import reascript_api as RPR
 from reapy.core import ReapyObject
 from reapy.tools import Program
@@ -130,8 +131,7 @@ class Envelope(ReapyObject):
 
         :type: list of reapy.AutomationItem
         """
-        n_items = self.n_items
-        items = [reapy.AutomationItem(self, i) for i in range(n_items)]
+        items = [reapy.AutomationItem(self, i) for i in range(self.n_items)]
         return items
 
     @property

--- a/reapy/core/item/item.py
+++ b/reapy/core/item/item.py
@@ -67,7 +67,7 @@ class Item(ReapyObject):
         take : Take
             index-th take of media item.
         """
-        take_id = RPR.GetItemTake(self.id, i)
+        take_id = RPR.GetItemTake(self.id, index)
         take = reapy.Take(take_id)
         return take
 
@@ -222,7 +222,7 @@ class Item(ReapyObject):
 
     @track.setter
     def track(self, track):
-        if isisintance(track, int):
+        if isinstance(track, int):
             track = reapy.Track(track, project=self.project)
         RPR.MoveMediaItemToTrack(self.id, track.id)
 

--- a/reapy/core/reaper/reaper.py
+++ b/reapy/core/reaper/reaper.py
@@ -113,7 +113,7 @@ def dB_to_slider(db):
     --------
     slider_to_dB
     """
-    sider = RPR.DB2SLIDER(db)
+    slider = RPR.DB2SLIDER(db)
     return slider
 
 

--- a/reapy/core/track/send.py
+++ b/reapy/core/track/send.py
@@ -1,3 +1,4 @@
+import reapy
 from reapy import reascript_api as RPR
 from reapy.core import ReapyObject
 from reapy.tools import Program

--- a/reapy/tools/dist_program.py
+++ b/reapy/tools/dist_program.py
@@ -28,6 +28,6 @@ class Program(program.Program):
 
     def run(self, **input):
         if reapy.is_inside_reaper():
-            return super(DistProgram, self).run(**input)
+            return super(Program, self).run(**input)
         else:
             return CLIENT.run_program(self, input)


### PR DESCRIPTION
Fix mistypes and error calls

1. Got `NameError` in `core.envelope` and `core.track.send`  because `reapy` was not imported there, so I decided to use `Program` to let it work without importing. (I've checked manually that it works now).
2. Didn't find any mention about `DistProgram` through the whole codebase, neither any magic which would allow `DistProgram` to be found inside `tools.dist_program`. I believe it was just a mistype during adding `tools.dist_program.Program` instead of `DistFunc`, so I fixed it.
3. The rest are obvious mistypes.