### PR TITLE
fix: don't show BrokenPipeError in Reaper console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
   * Properties [`Track.is_solo`] and [`Track.is_muted`]. Manually setting them is equivalent to calling the methods above.
 
 ### Fixed
+- Fix `BrokenPipeError` when an external app disconnects silently
 - Fix setting color in [`Project.add_marker`] and [`Project.add_region`] methods
 
 ## [0.3.0](https://github.com/RomeoDespres/reapy/releases/tag/0.3.0) - 2019-05-08

--- a/reapy/reascript_api/network/server.py
+++ b/reapy/reascript_api/network/server.py
@@ -113,7 +113,7 @@ class Server(Socket):
             try:
                 connection = self.connections[address]
                 self._send_result(connection, result)
-            except KeyError:
+            except (KeyError, BrokenPipeError):
                 # Happens when the client requested to disconnect.
                 # Nothing must be returned in that case.
                 pass


### PR DESCRIPTION
When an external app disconnects silently (or a developer's python shell is shut down) reapy would show `BrokenPipeError` in Reaper console.
It is rather annoying, hence this commit.