### PR TITLE
added is_connected()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `reapy.reconnect` to retry connecting to REAPER from the outside.
+-  `reapy.is_connected` to retrive connection status and REAPER host.
 
 
 ## [0.4.3](https://github.com/RomeoDespres/reapy/releases/tag/0.4.3) - 2019-10-27

--- a/reapy/__init__.py
+++ b/reapy/__init__.py
@@ -24,7 +24,7 @@ def is_inside_reaper():
 
 from .tools import (
     connect, connect_to_default_machine, dist_api_is_enabled, inside_reaper,
-    reconnect
+    reconnect, is_connected
 )
 from . import reascript_api
 from .core import *

--- a/reapy/__init__.pyi
+++ b/reapy/__init__.pyi
@@ -10,7 +10,7 @@ def is_inside_reaper() -> bool:
 
 from .tools import (
     connect, connect_to_default_machine, dist_api_is_enabled, inside_reaper,
-    reconnect
+    reconnect, is_connected
 )
 from . import reascript_api as reascript_api
 from .core import *
@@ -102,4 +102,5 @@ __all__ = [
     'dist_api_is_enabled',
     'inside_reaper',
     'reconnect',
+    'is_connected',
 ]

--- a/reapy/tools/__init__.py
+++ b/reapy/tools/__init__.py
@@ -2,4 +2,5 @@
 
 import reapy
 from ._inside_reaper import inside_reaper, dist_api_is_enabled
-from .network.machines import connect, connect_to_default_machine, reconnect
+from .network.machines import (
+    connect, connect_to_default_machine, reconnect, is_connected)

--- a/reapy/tools/__init__.pyi
+++ b/reapy/tools/__init__.pyi
@@ -2,7 +2,8 @@
 
 import reapy
 from ._inside_reaper import inside_reaper, dist_api_is_enabled
-from .network.machines import connect, connect_to_default_machine, reconnect
+from .network.machines import (
+    connect, connect_to_default_machine, reconnect, is_connected)
 
 __all__ = [
     'inside_reaper',
@@ -10,4 +11,5 @@ __all__ = [
     'connect',
     'connect_to_default_machine',
     'reconnect',
+    'is_connected',
 ]

--- a/reapy/tools/network/machines.py
+++ b/reapy/tools/network/machines.py
@@ -64,6 +64,22 @@ def reconnect():
         connect(host)
 
 
+def is_connected():
+    """
+    Get connection state of reapy.
+
+    Returns
+    -------
+    Union[str, bool]
+        if connected — returns host as str (localhost also can be returned)
+        if not — returns False
+    """
+    global CLIENT
+    if CLIENT is None:
+        return False
+    return CLIENT.host
+
+
 class connect:
 
     """Connect to slave machine.

--- a/reapy/tools/network/machines.pyi
+++ b/reapy/tools/network/machines.pyi
@@ -57,6 +57,19 @@ def reconnect() -> None:
     ...
 
 
+def is_connected() -> ty.Union[str, bool]:
+    """
+    Get connection state of reapy.
+
+    Returns
+    -------
+    Union[str, bool]
+        if connected — returns host as str (localhost also can be returned)
+        if not — returns False
+    """
+    ...
+
+
 class connect:
 
     """Connect to slave machine.


### PR DESCRIPTION
It allows, at least, using conditional-based skip in the tests

```Python
@pytest.mark.skipif(not rpr.is_connected(), reason='not connected to reaper')
def test_bus_packed():
    def track(id: str) -> ss.Track:
        r_tr = rpr.Track(id=id)
        return ss.Track(r_tr)
```