### PR TITLE
fix: error in region.end getter

### DIFF
--- a/reapy/core/project/region.py
+++ b/reapy/core/project/region.py
@@ -27,7 +27,7 @@ class Region(ReapyObject):
         """
         return next(
             i for i, r in enumerate(reapy.Project(self.project_id).regions)
-            if r.index == region.index
+            if r.index == self.index
         )
 
     @property


### PR DESCRIPTION
This PR will:

* Fix an incorrect reference to `region` in the `region.end` getter function