### PR TITLE
Fix typo for Jedi and mypy

### DIFF
--- a/reapy/__init__.py
+++ b/reapy/__init__.py
@@ -28,7 +28,44 @@ from .tools import (
 )
 from . import reascript_api
 from .config import configure_reaper
-from .core import *
+from .core import (
+    # from .reapy_object
+    ReapyObject,
+    ReapyObjectList,
+    # from .project
+    Marker,
+    Project,
+    Region,
+    TimeSelection,
+    # from .audio_accessor
+    AudioAccessor,
+    # from .envelope
+    Envelope,
+    EnvelopeList,
+    EnvelopePoint,
+    # from .fx
+    FX,
+    FXList,
+    FXParam,
+    FXParamsList,
+    # from .item
+    CC,
+    CCList,
+    Item,
+    Note,
+    NoteList,
+    Source,
+    Take,
+    # from .track
+    AutomationItem,
+    Send,
+    Track,
+    TrackList,
+    # from .window
+    MIDIEditor,
+    ToolTip,
+    Window,
+)
 from .core.reaper import *
 
 

--- a/reapy/__init__.pyi
+++ b/reapy/__init__.pyi
@@ -5,6 +5,7 @@ from .tools import (
     connect, connect_to_default_machine, dist_api_is_enabled, inside_reaper,
     reconnect
 )
+from .config import configure_reaper
 import sys
 
 
@@ -14,11 +15,16 @@ def is_inside_reaper() -> bool:
     """
     ...
 
-
 __all__ = [
+    "reascript_api",
     # core.reapy_object
     "ReapyObject",
     "ReapyObjectList",
+    # core.project
+    "Marker",
+    "Project",
+    "Region",
+    "TimeSelection",
     # core.audio_accessor
     "AudioAccessor",
     # core.envelope
@@ -37,11 +43,6 @@ __all__ = [
     "NoteList",
     "Source",
     "Take",
-    # core.project
-    "Marker",
-    "Project",
-    "Region",
-    "TimeSelection",
     # core.track
     "AutomationItem",
     "Send",

--- a/reapy/config/__init__.pyi
+++ b/reapy/config/__init__.pyi
@@ -1,0 +1,15 @@
+from .config import *
+from .shared_library import get_python_shared_library
+
+__all__ = [
+    'add_web_interface',
+    'configure_reaper',
+    'create_new_web_interface',
+    'delete_web_interface',
+    'disable_dist_api',
+    'enable_dist_api',
+    'enable_python',
+    'REAPY_SERVER_PORT',
+    'WEB_INTERFACE_PORT',
+    "get_python_shared_library",
+]

--- a/reapy/config/config.pyi
+++ b/reapy/config/config.pyi
@@ -16,6 +16,18 @@ WEB_INTERFACE_PORT = 2307
 T1 = ty.TypeVar('T1')
 T2 = ty.TypeVar('T2')
 
+__all__ = [
+    'add_web_interface',
+    'configure_reaper',
+    'create_new_web_interface',
+    'delete_web_interface',
+    'disable_dist_api',
+    'enable_dist_api',
+    'enable_python',
+    'REAPY_SERVER_PORT',
+    'WEB_INTERFACE_PORT',
+]
+
 
 class CaseInsensitiveDict(OrderedDict[str, T1]):
     """OrderedDict with case-insensitive keys."""
@@ -46,6 +58,111 @@ class Config(ConfigParser):
         ...
 
 
+def add_reascript(resource_path: str, script_path: str) -> str:
+    """Add ReaScript to *Actions* list in REAPER.
+
+    Works by manually editing ``reaper-kb.ini`` configuration file.
+    Only use this function at setup time to configure REAPER.
+    In other cases, make use of :func:`reapy.add_reascript`.
+
+    In case ``script_path`` is already in Actions list, its command
+    name is returned but it is not added a second time.
+
+    Parameters
+    ----------
+    resource_path : str
+        Path to REAPER resource directory. Can be obtained with
+        :func:`reapy.config.resource_path.get_resource_path`.
+    script_path : str
+        Path to script that will be added.
+
+    Returns
+    -------
+    str
+        Action name for the newly added ReaScript.
+
+    Raises
+    ------
+    FileNotFoundError
+        When ``script_path`` does not exist.
+    ValueError
+        When ``script_path`` is not a Python module.
+    """
+    ...
+
+
+def add_web_interface(
+    resource_path: str, port: int = WEB_INTERFACE_PORT
+) -> None:
+    """Add a REAPER Web Interface at a specified port.
+
+    It is added by manually editing reaper.ini configuration file,
+    which is loaded on startup. Thus, the added web interface will
+    only be available after restarting REAPER.
+
+    Nothing happens in case a web interface already exists at
+    ``port``.
+
+    Parameters
+    ----------
+    resource_path : str
+        Path to REAPER resource directory. Can be obtained with
+        :func:`reapy.config.resource_path.get_resource_path`.
+    port : int, optional
+        Web interface port. Default=``2307``.
+    """
+
+
+def configure_reaper(
+    resource_path: ty.Optional[str] = None,
+    detect_portable_install: bool = True
+) -> None:
+    """Configure REAPER to allow reapy connections.
+
+    Allows to use reapy from outside REAPER.
+
+    Configuration is done by manually editing ``reaper.ini``
+    and ``reaper-kb.ini``. It consists in the following steps:
+    1. Enable usage of Python for ReaScripts.
+    2. Fill in path to python shared library (.dll, .dylib or .so).
+    3. Add a web interface on port 2307 to listen to reapy
+       connections.
+    4. Add the ReaScript ``reapy.reascripts.activate_reapy_server``
+       to the *Actions* list.
+    5. Add the name of this action to REAPER external state.
+
+    It is safe to call this function several times as it only edits
+    configuration files when needed.
+
+    Parameters
+    ----------
+    resource_path : str or None, optional
+        Path to REAPER resource directory. When ``None``, defaults to
+        the result of
+        :func:`reapy.config.resource_path.get_resource_path`. Use it
+        if you already know where REAPER resource directory is
+        located at.
+    detect_portable_install : bool, optional
+        If ``True``, this function will look for a currently running
+        REAPER process and detect whether it is a portable install.
+        If ``False``, configuration files will be looked for in the
+        default locations only, which may result in a
+        ``FileNotFoundError`` if no global REAPER install exists.
+        Default=``True``.
+
+    Raises
+    ------
+    RuntimeError
+        When ``detect_portable_install=True`` and zero or more than one
+        REAPER instances are currently running.
+    FileNotFoundError
+        When ``detect_portable_install=False`` but no global
+        configuration file can be found (which means REAPER has only
+        been installed as portable.)
+    """
+    ...
+
+
 def create_new_web_interface(port: int) -> None:
     """
     Create a Web interface in REAPER at a specified port.
@@ -61,17 +178,22 @@ def create_new_web_interface(port: int) -> None:
     ...
 
 
-def delete_web_interface(port: int) -> None:
-    """
-    Delete Web interface listening to a specified port.
+def delete_web_interface(
+    resource_path: str, port: int = WEB_INTERFACE_PORT
+) -> None:
+    """Delete a REAPER Web Interface at a specified port.
 
-    It is deleted by writing a line directly in REAPER .ini file. Thus
-    it will only be deleted on restart.
+    It is deleted by manually editing reaper.ini configuration file,
+    which is loaded on startup. Thus, the web interface stay alive
+    until REAPER is closed.
 
     Parameters
     ----------
-    port : int
-        Web interface port.
+    resource_path : str
+        Path to REAPER resource directory. Can be obtained with
+        :func:`reapy.config.resource_path.get_resource_path`.
+    port : int, optional
+        Web interface port. Default=``2307``.
     """
     ...
 
@@ -97,6 +219,76 @@ def enable_dist_api() -> None:
     ...
 
 
+def enable_python(resource_path: str) -> None:
+    ...
+
+
 def get_activate_reapy_server_path() -> str:
     """Return path to the ``activate_reapy_server`` ReaScript."""
+    ...
+
+
+def get_new_reascript_code(ini_file: str) -> str:
+    """Return new ReaScript code for reaper-kb.ini.
+
+    Parameters
+    ----------
+    ini_file : str
+        Path to ``reaper-kb.ini`` configuration file.
+
+    Returns
+    -------
+    code : str
+        ReaScript code.
+    """
+    ...
+
+
+def set_ext_state(
+    section: str, key: str, value: str, resource_path: str
+) -> str:
+    """Update REAPER external state.
+
+    Works by manually editing ``reaper-extstate.ini`` configuration file.
+    Only use this function at setup time to configure REAPER.
+    In other cases, make use of :func:`reapy.set_ext_state`.
+
+    Parameters
+    ----------
+    section : str
+        External state section.
+    key : str
+        External state key in ``section``.
+    value : str
+        External state value for ``key`` in ``section``.
+    resource_path : str
+        Path to REAPER resource directory. Can be obtained with
+        :func:`reapy.config.resource_path.get_resource_path`.
+
+    Returns
+    -------
+    str
+        Action name for the newly added ReaScript.
+    """
+    ...
+
+
+def web_interface_exists(
+    resource_path: str, port: int = WEB_INTERFACE_PORT
+) -> bool:
+    """Return whether a REAPER Web Interface exists at a given port.
+
+    Parameters
+    ----------
+    resource_path : str
+        Path to REAPER resource directory. Can be obtained with
+        :func:`reapy.config.resource_path.get_resource_path`.
+    port : int, optional
+        Web interface port. Default=``2307``.
+
+    Returns
+    -------
+    bool
+        Whether a REAPER Web Interface exists at ``port``.
+    """
     ...

--- a/reapy/core/__init__.py
+++ b/reapy/core/__init__.py
@@ -1,13 +1,12 @@
 from .reapy_object import ReapyObject, ReapyObjectList
 
-from .project import Marker, Project, Region, TimeSelection
 from .audio_accessor import AudioAccessor
 from .envelope import Envelope, EnvelopeList
 from .fx import FX, FXList, FXParam, FXParamsList
 from .item import CC, CCList, Item, Note, NoteList, Source, Take
 from .track import AutomationItem, Send, Track, TrackList
+from .project import Marker, Project, Region, TimeSelection
 from .window import MIDIEditor, ToolTip, Window
-
 
 __all__ = [
     # core.reapy_object

--- a/reapy/core/__init__.py
+++ b/reapy/core/__init__.py
@@ -1,10 +1,10 @@
 from .reapy_object import ReapyObject, ReapyObjectList
 
+from .project import Marker, Project, Region, TimeSelection
 from .audio_accessor import AudioAccessor
 from .envelope import Envelope, EnvelopeList
 from .fx import FX, FXList, FXParam, FXParamsList
 from .item import CC, CCList, Item, Note, NoteList, Source, Take
-from .project import Marker, Project, Region, TimeSelection
 from .track import AutomationItem, Send, Track, TrackList
 from .window import MIDIEditor, ToolTip, Window
 

--- a/reapy/core/__init__.pyi
+++ b/reapy/core/__init__.pyi
@@ -1,11 +1,11 @@
 from .reapy_object import ReapyObject, ReapyObjectList
 
-from .project import Marker, Project, Region, TimeSelection
 from .audio_accessor import AudioAccessor
 from .envelope import Envelope, EnvelopeList
 from .fx import FX, FXList, FXParam, FXParamsList
 from .item import CC, CCList, Item, Note, NoteList, Source, Take
 from .track import AutomationItem, Send, Track, TrackList
+from .project import Marker, Project, Region, TimeSelection
 from .window import MIDIEditor, ToolTip, Window
 
 __all__ = [

--- a/reapy/core/__init__.pyi
+++ b/reapy/core/__init__.pyi
@@ -1,10 +1,10 @@
 from .reapy_object import ReapyObject, ReapyObjectList
 
+from .project import Marker, Project, Region, TimeSelection
 from .audio_accessor import AudioAccessor
 from .envelope import Envelope, EnvelopeList
 from .fx import FX, FXList, FXParam, FXParamsList
 from .item import CC, CCList, Item, Note, NoteList, Source, Take
-from .project import Marker, Project, Region, TimeSelection
 from .track import AutomationItem, Send, Track, TrackList
 from .window import MIDIEditor, ToolTip, Window
 
@@ -12,6 +12,11 @@ __all__ = [
     # core.reapy_object
     "ReapyObject",
     "ReapyObjectList",
+    # core.project
+    "Marker",
+    "Project",
+    "Region",
+    "TimeSelection",
     # core.audio_accessor
     "AudioAccessor",
     # core.envelope
@@ -30,11 +35,6 @@ __all__ = [
     "NoteList",
     "Source",
     "Take",
-    # core.project
-    "Marker",
-    "Project",
-    "Region",
-    "TimeSelection",
     # core.track
     "AutomationItem",
     "Send",

--- a/reapy/tools/__init__.pyi
+++ b/reapy/tools/__init__.pyi
@@ -6,11 +6,11 @@ from .network.machines import connect, connect_to_default_machine, reconnect
 from .extension_dependency import depends_on_sws, depends_on_extension
 
 __all__ = [
-    'inside_reaper',
-    'dist_api_is_enabled',
-    'connect',
-    'connect_to_default_machine',
-    'reconnect',
-    'depends_on_sws',
-    'depends_on_extension',
+    "inside_reaper",
+    "dist_api_is_enabled",
+    "connect",
+    "connect_to_default_machine",
+    "reconnect",
+    "depends_on_sws",
+    "depends_on_extension",
 ]


### PR DESCRIPTION
There're some issues  preventing correct working of Jedi and other completion tools. I can't say, why do they prefer to use `*.py` files considering some import processes, but they are. So, most of `reapy.__init__` contents are made available for Jedi parsing. Other `*.pyi` files are updated to be connected to the updated `*.py`.

<hr>

Actually, as far I go within modifying reapy source, as much I desire to get `*.pyi` files out and put type hints directly to the code.

I see, that the mypy sources themselves are made without type hints, but while reapy is modified, stubs became incomplete, also I cannot use mypy on the reapy source itself during my work on it and this is quite uncommon for me. I can't say if it is a problem for other contributors.

May we discuss such possibility?))