### PR TITLE
Add reapy.map function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- [`reapy.map`](https://python-reapy.readthedocs.io/en/latest/reapy.core.html#reapy.core.map) for efficient mapping of `reapy` functions to large iterables of arguments.
+
 ### Fixed
 
 - Native ReaScript functions `RPR_MIDI_GetAllEvts`, `RPR_MIDI_GetTextSysexEvt`, `RPR_MIDI_SetAllEvts`, `RPR_MIDI_SetCC`, `RPR_MIDI_SetEvt`, `RPR_MIDI_SetNote` and `RPR_MIDI_SetTextSysexEvt` used to raise errors because they tried to encode MIDI messages as UTF-8. Their counterparts in `reapy.reascript_api` are patched and work as described in the official ReaScript documentation.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ When used from inside REAPER, `reapy` has almost identical performance than nati
 
 ```
 
+A small overhead due to sending function and arguments over the network will still occur each time a `reapy` function is called from outside REAPER. When running the same function many times in a row (e.g. over a thousand times), using [`reapy.map`](https://python-reapy.readthedocs.io/en/latest/reapy.core.html#reapy.core.map) may significantly increase performance. See its documentation for more details.
+
 ### Documentation
 
 Check the [documentation](https://python-reapy.readthedocs.io/ "reapy online documentation") and especially the [API guide](https://python-reapy.readthedocs.io/en/latest/api_guide.html) and [Translation Table](https://python-reapy.readthedocs.io/en/latest/api_table.html) for more information.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,6 +86,12 @@ When used from inside REAPER, ``reapy`` has almost identical performance than na
     ...
     >>> # Takes only 0.1 second!
 
+A small overhead due to sending function and arguments over the network will
+still occur each time a ``reapy`` function is called from outside REAPER. When
+running the same function many times in a row (e.g. over a thousand times), using
+:py:func:`reapy.map <reapy.core.map>` may significantly increase performance.
+See its documentation for more details.
+
 API documentation
 -----------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Welcome to reapy's documentation!
 .. toctree::
    :maxdepth: 2
    :hidden:
-   
+
    Api guide <api_guide.html#://>
    Translation Table <api_table.html#://>
    Install or uninstall reapy <install_guide.html#://>
@@ -19,7 +19,7 @@ Welcome to reapy's documentation!
 .. contents:: Contents
     :local:
     :depth: 3
-   
+
 ``reapy`` is a nice pythonic wrapper around the quite unpythonic `ReaScript Python API <https://www.reaper.fm/sdk/reascript/reascripthelp.html#p>`_ for `REAPER <https://www.reaper.fm/>`_.
 
 Installation
@@ -86,8 +86,6 @@ When used from inside REAPER, ``reapy`` has almost identical performance than na
     ...
     >>> # Takes only 0.1 second!
 
-Although this method should be sufficient in most cases, note that optimality is only reached by making use of ``reapy.tools.Program`` (see documentation `here <reapy.tools.html#reapy.tools.program.Program>`_).
-    
 API documentation
 -----------------
 

--- a/reapy/core/__init__.py
+++ b/reapy/core/__init__.py
@@ -4,6 +4,7 @@ from .audio_accessor import AudioAccessor
 from .envelope import Envelope, EnvelopeList
 from .fx import FX, FXList, FXParam, FXParamsList
 from .item import CC, CCList, Item, Note, NoteList, Source, Take
+from .map import map
 from .project import Marker, Project, Region, TimeSelection
 from .track import AutomationItem, Send, Track, TrackList
 from .window import MIDIEditor, ToolTip, Window
@@ -31,6 +32,8 @@ __all__ = [
     "NoteList",
     "Source",
     "Take",
+    # core.map
+    "map",
     # core.project
     "Marker",
     "Project",

--- a/reapy/core/__init__.pyi
+++ b/reapy/core/__init__.pyi
@@ -30,6 +30,8 @@ __all__ = [
     "NoteList",
     "Source",
     "Take",
+    # core.map
+    "map",
     # core.project
     "Marker",
     "Project",

--- a/reapy/core/map.py
+++ b/reapy/core/map.py
@@ -40,7 +40,7 @@ def map(function, *iterables, constants={}, kwargs_iterable=None):
 
     Returns
     -------
-    :type: list
+    list
         The list of results of each calls. Unlike the built-in Python
         function ``map``, it does not return an iterator.
 

--- a/reapy/core/map.py
+++ b/reapy/core/map.py
@@ -1,0 +1,73 @@
+import builtins
+import functools
+
+import reapy
+
+
+@reapy.inside_reaper()
+def map(function, *iterables, constants={}, kwargs_iterable=None):
+    """Efficiently map a function to iterables of arguments.
+
+    From outside REAPER, reapy function calls are sent over the
+    network for REAPER to execute them. The result in then sent back
+    to the reapy client.
+
+    When calling a large number of reapy functions, the network
+    overhead can become significant. To solve this problem,
+    ``reapy.map`` sends all arguments at once and retrieves all
+    results at once.
+
+    It extends the API of the built-in Python function ``map`` with
+    keyword arguments options.
+
+    It stops when the shortest of ``kwargs_iterable`` and all
+    iterables in ``iterables`` is exhausted.
+
+    Parameters
+    ----------
+    function : reapy callable
+        Function to map to iterables of arguments.
+    iterables : tuple of iterables
+        Iterables of arguments that will be iterated in parallel and
+        passed to ``function`` as positional arguments.
+    constants : dict, optional
+        Constant keyword arguments that will be passed  to
+        ``function`` at each call.
+    kwargs_iterable : iterable of mappings
+        Iterable yielding mappings of keyword arguments that will be
+        passed to ``function`` alongside the positional arguments in
+        ``iterables``.
+
+    Returns
+    -------
+    :type: list
+        The list of results of each calls. Unlike the built-in Python
+        function ``map``, it does not return an iterator.
+
+    Examples
+    --------
+    Below is a simple use case where ``reapy.map`` reduces run time
+    by 95%.
+
+    >>> import time
+    >>> import reapy
+    >>>
+    >>> project = reapy.Project()
+    >>> take = project.items[0].active_take
+    >>> with reapy.inside_reaper():
+    ...     start_time = time.time()
+    ...     ppqs = [take.time_to_ppq(time) for time in range(10**5)]
+    ...     print(f'Elapsed time without reapy.map: {time.time() - start_time:.1f} s.')
+    ...
+    Elapsed time without reapy.map: 15.0 s.
+    >>>
+    >>> start_time = time.time()
+    >>> ppqs = reapy.map(take.time_to_ppq, list(range(10**5)))
+    >>> print(f'Elapsed time with reapy.map: {time.time() - start_time:.1f} s.')
+    Elapsed time with reapy.map: 0.7 s.
+    """
+    if kwargs_iterable is None:
+        kwargs_iterable = iter(dict, None)
+    partial_function = functools.partial(function, **constants)
+    function = lambda *args: partial_function(*args[1:], **args[0])
+    return list(builtins.map(function, kwargs_iterable, *iterables))

--- a/reapy/core/map.pyi
+++ b/reapy/core/map.pyi
@@ -1,0 +1,10 @@
+import typing as ty
+
+
+def map(
+    function: ty.Callable,
+    *iterables: ty.Iterable,
+    constants: ty.Mapping[str, ty.Any] = ...,
+    kwargs_iterable: ty.Optional[ty.Iterable[ty.Mapping[str, ty.Any]]] = ...
+) -> list:
+    ...

--- a/reapy/core/reapy_object.py
+++ b/reapy/core/reapy_object.py
@@ -1,5 +1,7 @@
 import reapy
 import reapy.reascript_api as RPR
+from functools import partial
+from pickle import dumps
 
 
 class ReapyMetaclass(type):
@@ -13,17 +15,18 @@ class ReapyMetaclass(type):
 
 
 class ReapyObject(metaclass=ReapyMetaclass):
-
     """Base class for reapy objects."""
 
     def __eq__(self, other):
         return repr(self) == repr(other)
 
     def __repr__(self):
+
         def to_str(x):
             if isinstance(x, str):
                 return "\"{}\"".format(x)
             return str(x)
+
         args = ", ".join(map(to_str, self._args))
         kwargs = ", ".join(
             ("{}={}".format(k, to_str(v)) for k, v in self._kwargs.items())
@@ -61,9 +64,65 @@ class ReapyObject(metaclass=ReapyMetaclass):
             "kwargs": self._kwargs
         }
 
+    @reapy.inside_reaper()
+    def map(self, method_name, iterables, defaults=None, pickled_out=False):
+        """
+        Perform object method among iterables inside reaper.
+
+        Note
+        ----
+        Opposite to `inside_reaper`, which saves on defered executions,
+        map saves on socket connections, so, basically, if you have complex
+        code needs to be performed at one deferred call — use `inside_reaper`,
+        if large amount of data has to be proceed within particular method —
+        use `object.map()`.
+
+        Parameters
+        ----------
+        method_name : str
+            name of the object method (self)
+        iterables : Dict[str, List[jsonable]]
+            str is argument name, List for mapping
+        defaults : Dict[str, jsonable]
+            partial arguments, that won't be changed though iteration
+        pickled_out: bool, optional
+            if True — returns pickled object
+
+        Returns
+        -------
+        List[<method result>]
+
+        Example
+        -------
+        import reapy as rpr
+        take = rpr.Project().selected_items[0].active_take
+
+        @rpr.inside_reaper()
+        def test():
+            for i in [6.0] * 1000000:
+                take.time_to_ppq(6.0)
+
+
+        def test_map():
+            take.map('time_to_ppq', iterables={'time': [6.0] * 1000000})
+
+
+        test()      # runs 140s
+        test_map()  # runs 12s as from outside as from inside
+        """
+        result = []
+        if defaults:
+            part_func = partial(getattr(self, method_name), **defaults)
+        else:
+            part_func = getattr(self, method_name)
+
+        for values in zip(*iterables.values()):
+            rest = {k: v for k, v in zip(iterables.keys(), values)}
+            result.append(part_func(**rest))
+        return result if not pickled_out else dumps(result).decode('latin-1')
+
 
 class ReapyObjectList(ReapyObject):
-
     """Abstract class for list of ReapyObjects."""
 
     pass

--- a/reapy/core/reapy_object.py
+++ b/reapy/core/reapy_object.py
@@ -1,7 +1,5 @@
 import reapy
 import reapy.reascript_api as RPR
-from functools import partial
-from pickle import dumps
 
 
 class ReapyMetaclass(type):
@@ -63,63 +61,6 @@ class ReapyObject(metaclass=ReapyMetaclass):
             "args": self._args,
             "kwargs": self._kwargs
         }
-
-    @reapy.inside_reaper()
-    def map(self, method_name, iterables, defaults=None, pickled_out=False):
-        """
-        Perform object method among iterables inside reaper.
-
-        Note
-        ----
-        Opposite to `inside_reaper`, which saves on defered executions,
-        map saves on socket connections, so, basically, if you have complex
-        code needs to be performed at one deferred call — use `inside_reaper`,
-        if large amount of data has to be proceed within particular method —
-        use `object.map()`.
-
-        Parameters
-        ----------
-        method_name : str
-            name of the object method (self)
-        iterables : Dict[str, List[jsonable]]
-            str is argument name, List for mapping
-        defaults : Dict[str, jsonable]
-            partial arguments, that won't be changed though iteration
-        pickled_out: bool, optional
-            if True — returns pickled object
-
-        Returns
-        -------
-        List[<method result>]
-
-        Example
-        -------
-        import reapy as rpr
-        take = rpr.Project().selected_items[0].active_take
-
-        @rpr.inside_reaper()
-        def test():
-            for i in [6.0] * 1000000:
-                take.time_to_ppq(6.0)
-
-
-        def test_map():
-            take.map('time_to_ppq', iterables={'time': [6.0] * 1000000})
-
-
-        test()      # runs 140s
-        test_map()  # runs 12s as from outside as from inside
-        """
-        result = []
-        if defaults:
-            part_func = partial(getattr(self, method_name), **defaults)
-        else:
-            part_func = getattr(self, method_name)
-
-        for values in zip(*iterables.values()):
-            rest = {k: v for k, v in zip(iterables.keys(), values)}
-            result.append(part_func(**rest))
-        return result if not pickled_out else dumps(result).decode('latin-1')
 
 
 class ReapyObjectList(ReapyObject):

--- a/reapy/core/reapy_object.pyi
+++ b/reapy/core/reapy_object.pyi
@@ -39,60 +39,6 @@ class ReapyObject:
     def _to_dict(self) -> ReapyObjectDict:
         ...
 
-    def map(
-        self,
-        method_name: str,
-        iterables: ty.Dict[str, object],
-        defaults: ty.Optional[ty.Dict[str, object]] = None,
-        pickled_out: bool = False
-    ) -> ty.List[object]:
-        """
-        Perform object method among iterables inside reaper.
-
-        Note
-        ----
-        Opposite to `inside_reaper`, which saves on defered executions,
-        map saves on socket connections, so, basically, if you have complex
-        code needs to be performed at one deferred call — use `inside_reaper`,
-        if large amount of data has to be proceed within particular method —
-        use `object.map()`.
-
-        Parameters
-        ----------
-        method_name : str
-            name of the object method (self)
-        iterables : Dict[str, List[jsonable]]
-            str is argument name, List for mapping
-        defaults : Dict[str, jsonable]
-            partial arguments, that won't be changed though iteration
-        pickled_out: bool, optional
-            if True — returns pickled object
-
-        Returns
-        -------
-        List[<method result>]
-
-        Example
-        -------
-        import reapy as rpr
-        take = rpr.Project().selected_items[0].active_take
-
-        @rpr.inside_reaper()
-        def test():
-            for i in [6.0] * 1000000:
-                take.time_to_ppq(6.0)
-
-
-        def test_map():
-            take.map('time_to_ppq', iterables={'time': [6.0] * 1000000})
-
-
-        test()      # runs 140s
-        test_map()  # runs 12s as from outside as from inside
-        """
-        ...
-
-
 class ReapyObjectList(ReapyObject):
     """Abstract class for list of ReapyObjects."""
 

--- a/reapy/core/reapy_object.pyi
+++ b/reapy/core/reapy_object.pyi
@@ -8,11 +8,13 @@ ReapyObjectDict = TypedDict(
         "class": str,
         "args": ty.Tuple[ty.Any, ...],
         "kwargs": ty.Dict[str, ty.Any]
-    })
+    }
+)
 
 
 class ReapyObject:
     """Base class for reapy objects."""
+
     def __eq__(self, other: object) -> bool:
         ...
 
@@ -35,6 +37,59 @@ class ReapyObject:
         ...
 
     def _to_dict(self) -> ReapyObjectDict:
+        ...
+
+    def map(
+        self,
+        method_name: str,
+        iterables: ty.Dict[str, object],
+        defaults: ty.Optional[ty.Dict[str, object]] = None,
+        pickled_out: bool = False
+    ) -> ty.List[object]:
+        """
+        Perform object method among iterables inside reaper.
+
+        Note
+        ----
+        Opposite to `inside_reaper`, which saves on defered executions,
+        map saves on socket connections, so, basically, if you have complex
+        code needs to be performed at one deferred call — use `inside_reaper`,
+        if large amount of data has to be proceed within particular method —
+        use `object.map()`.
+
+        Parameters
+        ----------
+        method_name : str
+            name of the object method (self)
+        iterables : Dict[str, List[jsonable]]
+            str is argument name, List for mapping
+        defaults : Dict[str, jsonable]
+            partial arguments, that won't be changed though iteration
+        pickled_out: bool, optional
+            if True — returns pickled object
+
+        Returns
+        -------
+        List[<method result>]
+
+        Example
+        -------
+        import reapy as rpr
+        take = rpr.Project().selected_items[0].active_take
+
+        @rpr.inside_reaper()
+        def test():
+            for i in [6.0] * 1000000:
+                take.time_to_ppq(6.0)
+
+
+        def test_map():
+            take.map('time_to_ppq', iterables={'time': [6.0] * 1000000})
+
+
+        test()      # runs 140s
+        test_map()  # runs 12s as from outside as from inside
+        """
         ...
 
 

--- a/reapy/tools/json.pyi
+++ b/reapy/tools/json.pyi
@@ -1,6 +1,7 @@
 """Encode and decode ``reapy`` objects as JSON."""
 
 import importlib
+import inspect
 import json
 import operator
 import sys


### PR DESCRIPTION
This pull request implements a new `reapy.map` function for efficiently mapping a function to iterables of arguments from outside REAPER.

It isolates this contribution from the rest of #81 where it was originally submitted.