### PR TITLE
fixed track.midi_note_names

### DIFF
--- a/reapy/additional_api.py
+++ b/reapy/additional_api.py
@@ -280,3 +280,27 @@ def ValidatePtr2(p0, p1, p2):
     pointer = ct.c_uint64(p1)
     name = _RPR.rpr_packsc(p2)
     return f(project, pointer, name)
+
+
+def GetTrackMIDINoteName(track_idx: int, pitch: int, chan: int) -> str:
+    a = _RPR._ft['GetTrackMIDINoteName']
+    f = ct.CFUNCTYPE(ct.c_char_p, ct.c_int, ct.c_int, ct.c_int)(a)
+    t = (ct.c_int(track_idx), ct.c_int(pitch), ct.c_int(chan))
+    r = f(t[0], t[1], t[2])
+    return '' if not r else str(r.decode())
+
+
+def GetTrackMIDINoteNameEx(
+    project: str, track: str, pitch: int, chan: int
+) -> str:
+    a = _RPR._ft['GetTrackMIDINoteNameEx']
+    f = ct.CFUNCTYPE(
+        ct.c_char_p, ct.c_uint64, ct.c_uint64, ct.c_int, ct.c_int
+    )(a)
+    t = (
+        packp('ReaProject*',
+              project), packp('MediaTrack*',
+                              track), ct.c_int(pitch), ct.c_int(chan)
+    )
+    r = f(t[0], t[1], t[2], t[3])
+    return '' if not r else str(r.decode())

--- a/reapy/core/track/track.py
+++ b/reapy/core/track/track.py
@@ -475,7 +475,9 @@ class Track(ReapyObject):
     def midi_note_names(self):
         with reapy.inside_reaper():
             names = [
-                RPR.GetTrackMIDINoteName(self.id, i, 0) for i in range(128)
+                RPR.GetTrackMIDINoteName(  # type:ignore
+                    self.index, i, 0
+                ) for i in range(128)
             ]
         return names
 


### PR DESCRIPTION
there was error in reaper_python that raised exception on empty strings.
Also, `GetTrackMidiNoteName` uses track index, not id